### PR TITLE
Improve the GetCrossSectionPropertiesAt method

### DIFF
--- a/BriefFiniteElementNet.TestConsole/Program.cs
+++ b/BriefFiniteElementNet.TestConsole/Program.cs
@@ -671,7 +671,7 @@ namespace BriefFiniteElementNet.TestConsole
             var iy = 0.03;
             var iz = 0.02;
             var a = 0.01;
-            var j = 0.05;
+            var j = iy + iz;
 
             var e = 7;
             var g = 11;
@@ -699,7 +699,7 @@ namespace BriefFiniteElementNet.TestConsole
 
 
             //barElement.Material = new UniformBarMaterial(e, g, rho);
-            barElement.Section = new UniformParametric1DSection() {Iy = iy, Iz = iz, A = a,J=j};
+            barElement.Section = new UniformParametric1DSection() {Iy = iy, Iz = iz, A = a};
 
             frameElement.MassFormulationType = MassFormulation.Consistent;
 

--- a/BriefFiniteElementNet.Validation/BarElementTester.cs
+++ b/BriefFiniteElementNet.Validation/BarElementTester.cs
@@ -690,7 +690,8 @@ namespace BriefFiniteElementNet.Validation
             var iy = 0.02;
             var iz = 0.02;
             var a = 0.01;
-            var j = 0.05;
+
+            var j = iy + iz;
 
             var e = 210e9;
             var g = 70e9;
@@ -720,7 +721,7 @@ namespace BriefFiniteElementNet.Validation
             frameElement.ConsiderShearDeformation = false;
 
             //barElement.Material = new UniformBarMaterial(e, g, rho);
-            barElement.Section = new UniformParametric1DSection() { Iy = iy, Iz = iz, A = a, J = j };
+            barElement.Section = new UniformParametric1DSection() { Iy = iy, Iz = iz, A = a };
 
             var frK = frameElement.GetGlobalStifnessMatrix();
             var barK = barElement.GetGlobalStifnessMatrix();
@@ -845,7 +846,7 @@ namespace BriefFiniteElementNet.Validation
             }
             #endregion
 
-
+            
             var span = new HtmlTag("span");
             span.Add("p").Text("Validate 3D frame nodal displacement and reactions");
             span.Add("h3").Text("Validate with");

--- a/BriefFiniteElementNet/BriefFiniteElementNet.csproj
+++ b/BriefFiniteElementNet/BriefFiniteElementNet.csproj
@@ -44,6 +44,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Elements\Extensions.cs" />
     <Compile Include="Utils\ArrayEqualityCompairer.cs" />
     <Compile Include="ElementHelpers\Gt9Helper.cs" />
     <Compile Include="ElementHelpers\TriangleBasicDrillingDofHelper.cs" />

--- a/BriefFiniteElementNet/Elements/BarElement.cs
+++ b/BriefFiniteElementNet/Elements/BarElement.cs
@@ -1291,28 +1291,6 @@ namespace BriefFiniteElementNet.Elements
             return b2.ToArray();
         }
 
-        #region peace add methods
-        /// <summary>
-        /// get the global displacement at xi
-        /// </summary>
-        /// <param name="xi"></param>
-        /// <param name="loadCase"></param>
-        /// <returns></returns>
-        public Displacement GetGlobalDisplacementAt(double xi, LoadCase loadCase)
-        {
-            var localDisp = GetInternalDisplacementAt(xi, loadCase);
-            var trMgr = GetTransformationManager();
-            return trMgr.TransformLocalToGlobal(localDisp);
-        }
-        /// <summary>
-        /// get the global displacement at xi for DefaultLoadCase
-        /// </summary>
-        /// <param name="xi"></param>
-        /// <returns></returns>
-        public Displacement GetGlobalDisplacementAt(double xi)
-        {
-            return GetGlobalDisplacementAt(xi, LoadCase.DefaultLoadCase);
-        }
-        #endregion
+        
     }
 }

--- a/BriefFiniteElementNet/Elements/BarElement.cs
+++ b/BriefFiniteElementNet/Elements/BarElement.cs
@@ -1290,5 +1290,29 @@ namespace BriefFiniteElementNet.Elements
 
             return b2.ToArray();
         }
+
+        #region peace add methods
+        /// <summary>
+        /// get the global displacement at xi
+        /// </summary>
+        /// <param name="xi"></param>
+        /// <param name="loadCase"></param>
+        /// <returns></returns>
+        public Displacement GetGlobalDisplacementAt(double xi, LoadCase loadCase)
+        {
+            var localDisp = GetInternalDisplacementAt(xi, loadCase);
+            var trMgr = GetTransformationManager();
+            return trMgr.TransformLocalToGlobal(localDisp);
+        }
+        /// <summary>
+        /// get the global displacement at xi for DefaultLoadCase
+        /// </summary>
+        /// <param name="xi"></param>
+        /// <returns></returns>
+        public Displacement GetGlobalDisplacementAt(double xi)
+        {
+            return GetGlobalDisplacementAt(xi, LoadCase.DefaultLoadCase);
+        }
+        #endregion
     }
 }

--- a/BriefFiniteElementNet/Elements/Extensions.cs
+++ b/BriefFiniteElementNet/Elements/Extensions.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace BriefFiniteElementNet.Elements
+{
+
+    public static class Extensions
+    {
+        #region peace add methods
+        /// <summary>
+        /// get the global displacement at xi
+        /// </summary>
+        /// <param name="xi"></param>
+        /// <param name="loadCase"></param>
+        /// <returns></returns>
+        public static Displacement GetGlobalDisplacementAt(this BarElement element, double xi, LoadCase loadCase)
+        {
+            var localDisp = element.GetInternalDisplacementAt(xi, loadCase);
+            var trMgr = element.GetTransformationManager();
+            return trMgr.TransformLocalToGlobal(localDisp);
+        }
+        /// <summary>
+        /// get the global displacement at xi for DefaultLoadCase
+        /// </summary>
+        /// <param name="xi"></param>
+        /// <returns></returns>
+        public static Displacement GetGlobalDisplacementAt(this BarElement element, double xi)
+        {
+            return element.GetGlobalDisplacementAt(xi, LoadCase.DefaultLoadCase);
+        }
+        
+        #endregion
+    }
+}

--- a/BriefFiniteElementNet/Elements/_1DCrossSectionGeometricProperties.cs
+++ b/BriefFiniteElementNet/Elements/_1DCrossSectionGeometricProperties.cs
@@ -10,12 +10,105 @@ namespace BriefFiniteElementNet.Elements
     /// </summary>
     public class _1DCrossSectionGeometricProperties
     {
+        /// <summary>
+        /// Calculates the cross section geometrical properties for given polygon
+        /// </summary>
+        /// <param name="points">the corners of polygon</param>
+        /// <param name="resetCentroid">if set to true, properties are calculated based on section centroid, if false then properties are calculated based on coordination system origins</param>
+        /// <returns>Geometrical properties of given polygon</returns>
+        public static _1DCrossSectionGeometricProperties Calculate(PointYZ[] points,bool resetCentroid)
+        {
+            var _geometry = points;
+
+
+            var buf = new _1DCrossSectionGeometricProperties();
+
+            {
+                var lastPoint = _geometry[_geometry.Length - 1];
+
+                if (lastPoint != _geometry[0])
+                    throw new InvalidOperationException("First point and last point on PolygonYz should put on each other");
+
+
+
+                double a = 0.0, iy = 0.0, ix = 0.0, ixy = 0.0;
+                double qy = 0.0, qx = 0.0;
+
+
+                var x = new double[_geometry.Length];
+                var y = new double[_geometry.Length];
+
+                for (int i = 0; i < _geometry.Length; i++)
+                {
+                    x[i] = _geometry[i].Y;
+                    y[i] = _geometry[i].Z;
+                }
+
+                var l = _geometry.Length - 1;
+
+                var ai = 0.0;
+
+                for (var i = 0; i < l; i++)
+                {
+                    //formulation: https://apps.dtic.mil/dtic/tr/fulltext/u2/a183444.pdf
+
+                    ai = x[i] * y[i + 1] - x[i + 1] * y[i];
+
+                    a += ai;
+
+                    ix += (x[i] * x[i] + x[i] * x[i + 1] + x[i + 1] * x[i + 1]) * ai;
+                    iy += (y[i] * y[i] + y[i] * y[i + 1] + y[i + 1] * y[i + 1]) * ai;
+
+                    qx += (x[i] + x[i + 1]) * ai;
+                    qy += (y[i] + y[i + 1]) * ai;
+
+                    ixy += (x[i] * y[i + 1] + 2 * x[i] * y[i] + 2 * x[i + 1] * y[i + 1] + x[i + 1] * y[i]) * ai;
+                }
+
+                a = a * 1 / 2.0;
+                qy = qy * 1 / 6.0;
+                qx = qx * 1 / 6.0;
+                iy = iy * 1 / 12.0;
+                ix = ix * 1 / 12.0;
+
+                ixy = ixy * 1 / 24.0;
+
+                var sign = Math.Sign(a);//sign is negative if points are in clock wise order
+
+                buf.A = sign * a;
+                buf.Qy = sign * qx;
+                buf.Qz = sign * qy;
+                buf.Iz = sign * iy;
+                buf.Iy = sign * ix;
+                buf.Iyz = sign * ixy;
+
+                buf.Ay = sign * a;//TODO: Ay is not equal to A, this is temporary fix
+                buf.Az = sign * a;//TODO: Az is not equal to A, this is temporary fix
+
+                if (resetCentroid)
+                {
+                    //parallel axis theorem
+                    buf.Iz -= buf.Qz * buf.Qz / buf.A;//A *D^2 = (A*D)*(A*D)/A
+                    buf.Iy -= buf.Qy * buf.Qy / buf.A;
+
+                    buf.Iyz -= buf.Qy * buf.Qz / buf.A;
+
+                    buf.Qy = 0;
+                    buf.Qz = 0;
+                }
+            }
+
+            return buf;
+        }
+
         private double _a;
         private double _ay;
         private double _az;
         private double _iy;
         private double _iz;
-        private double _j;
+        private double _qy;
+        private double _qz;
+        private double _iyz;
 
         /// <summary>
         /// Gets or sets a.
@@ -88,7 +181,41 @@ namespace BriefFiniteElementNet.Elements
         }
 
         /// <summary>
-        /// Gets or sets the j.
+        /// Gets or sets the Qy.
+        /// </summary>
+        /// <value>
+        /// The first Moment of Area of section regard to Z axis.
+        /// </value>
+        /// <remarks>
+        ///     /
+        /// Iy= | Z . dA
+        ///    /A
+        /// </remarks>
+        public double Qy
+        {
+            get { return _qy; }
+            set { _qy = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the Qz.
+        /// </summary>
+        /// <value>
+        /// The first Moment of Area of section regard to Y axis
+        /// </value>
+        /// <remarks>
+        ///     /
+        /// Iz= | Y . dA
+        ///    /A
+        /// </remarks>
+        public double Qz
+        {
+            get { return _qz; }
+            set { _qz = value; }
+        }
+
+        /// <summary>
+        /// Gets the polar moment of inertia (J).
         /// </summary>
         /// <value>
         /// The polar moment of inertial.
@@ -100,8 +227,24 @@ namespace BriefFiniteElementNet.Elements
         /// </remarks>
         public double J
         {
-            get { return _j; }
-            set { _j = value; }
+            get { return _iy + _iz; }
+        }
+
+        /// <summary>
+        /// Gets or sets the Iyz.
+        /// </summary>
+        /// <value>
+        /// The Product Moment of Area of section
+        /// </value>
+        /// <remarks>
+        ///      /
+        /// Iyz= | Y . Z . dA
+        ///      /A
+        /// </remarks>
+        public double Iyz
+        {
+            get { return _iyz; }
+            set { _iyz = value; }
         }
     }
 }

--- a/BriefFiniteElementNet/Model.cs
+++ b/BriefFiniteElementNet/Model.cs
@@ -596,6 +596,7 @@ namespace BriefFiniteElementNet
         #region peace add 
         /// <summary>
         /// 获得具有某label的node
+        /// Find and returns the node with certain label
         /// </summary>
         /// <param name="label"></param>
         /// <returns></returns>
@@ -615,6 +616,7 @@ namespace BriefFiniteElementNet
         }
         /// <summary>
         /// 获得具有某label的element
+        /// Find and returns the element with certain label
         /// </summary>
         /// <param name="label"></param>
         /// <returns></returns>

--- a/BriefFiniteElementNet/Model.cs
+++ b/BriefFiniteElementNet/Model.cs
@@ -592,5 +592,46 @@ namespace BriefFiniteElementNet
             MatrixPool = new MatrixPool(ArrayPool);
         }
         #endregion
+
+        #region peace add 
+        /// <summary>
+        /// 获得具有某label的node
+        /// </summary>
+        /// <param name="label"></param>
+        /// <returns></returns>
+        public Node NodeWithLabel(string label)
+        {
+            Node node = null;
+            foreach (Node nd in nodes)
+            {
+                if (nd.Label == label)
+                {
+                    node = nd;
+                    break;
+                }
+            }
+
+            return node;
+        }
+        /// <summary>
+        /// 获得具有某label的element
+        /// </summary>
+        /// <param name="label"></param>
+        /// <returns></returns>
+        public Element ElementWithLabel(string label)
+        {
+            Element element = null;
+            foreach (Element elm in elements)
+            {
+                if (elm.Label == label)
+                {
+                    element = elm;
+                    break;
+                }
+            }
+
+            return element;
+        }
+        #endregion
     }
 }

--- a/BriefFiniteElementNet/Sections/NonUniformGeometric1DSection.cs
+++ b/BriefFiniteElementNet/Sections/NonUniformGeometric1DSection.cs
@@ -50,7 +50,24 @@ namespace BriefFiniteElementNet.Sections
             }
         }
 
+        /// <summary>
+        /// If sets to true, all geometric properties are calculated based on centroid, not coordination system origins.
+        /// for more info see pull request #34
+        /// </summary>
+        /// <remarks>
+        /// If set to true, then all properties are calculated based on centroid, not coordination system origins. In this case <see cref="Qy"/> and <see cref="Qz"/> are zeros,
+        /// <see cref="Iy"/> and <see cref="Iz"/> and <see cref="Iyz"/> are calculated based on the section centroid. <see cref="A"/> do not change.
+        /// </remarks>
+        public bool ResetCentroid
+        {
+            get { return _resetCentroid; }
+            set
+            {
+                _resetCentroid = value;
+            }
+        }
 
+        private bool _resetCentroid;
 
         public override _1DCrossSectionGeometricProperties GetCrossSectionPropertiesAt(double xi)
         {
@@ -75,59 +92,9 @@ namespace BriefFiniteElementNet.Sections
                 target[i] = pt;
             }
 
-
             var _geometry = target;
-            var buf = new _1DCrossSectionGeometricProperties();
 
-            {
-                var lastPoint = _geometry[_geometry.Length - 1];
-
-                if (lastPoint != _geometry[0])
-                    throw new InvalidOperationException("First point and last point ot PolygonYz should put on each other");
-
-                double a = 0.0, iz = 0.0, iy = 0.0, ixy = 0.0;
-
-                var x = new double[_geometry.Length];
-                var y = new double[_geometry.Length];
-
-                for (int i = 0; i < _geometry.Length; i++)
-                {
-                    x[i] = _geometry[i].Y;
-                    y[i] = _geometry[i].Z;
-                }
-
-                var l = _geometry.Length - 1;
-
-                var ai = 0.0;
-
-                for (var i = 0; i < l; i++)
-                {
-                    ai = x[i] * y[i + 1] - x[i + 1] * y[i];
-                    a += ai;
-                    iy += (y[i] * y[i] + y[i] * y[i + 1] + y[i + 1] * y[i + 1]) * ai;
-                    iz += (x[i] * x[i] + x[i] * x[i + 1] + x[i + 1] * x[i + 1]) * ai;
-
-                    ixy += (x[i] * y[i + 1] + 2 * x[i] * y[i] + 2 * x[i + 1] * y[i + 1] + x[i + 1] * y[i]) * ai;
-
-                }
-
-                a = a * 0.5;
-                iz = iz * 1 / 12.0;
-                iy = iy * 1 / 12.0;
-                ixy = ixy * 1 / 24.0;
-                var j = iy + iz;
-                //not sure which one is correct j = ix + iy or j = ixy >:)~ 
-
-                buf.A = Math.Abs(a);
-                buf.Iz = Math.Abs(iz);
-                buf.Iy = Math.Abs(iy);
-                buf.J = Math.Abs(j);
-                buf.Ay = Math.Abs(a);//TODO: Ay is not equal to A, this is temporary fix
-                buf.Az = Math.Abs(a);//TODO: Az is not equal to A, this is temporary fix
-
-            }
-
-            return buf;
+            return _1DCrossSectionGeometricProperties.Calculate(target, this._resetCentroid);
         }
 
 

--- a/BriefFiniteElementNet/Sections/NonUniformParametric1DSection.cs
+++ b/BriefFiniteElementNet/Sections/NonUniformParametric1DSection.cs
@@ -67,7 +67,7 @@ namespace BriefFiniteElementNet.Sections
                 target.A = s1.A * f1 + s2.A * f2;
                 target.Ay = s1.Ay * f1 + s2.Ay * f2;
                 target.Az = s1.Az * f1 + s2.Az * f2;
-                target.J = s1.J * f1 + s2.J * f2;
+                target.Iyz = s1.Iyz * f1 + s2.Iyz * f2;
                 target.Iy = s1.Iy * f1 + s2.Iy * f2;
                 target.Iz = s1.Iz * f1 + s2.Iz * f2;
             }

--- a/BriefFiniteElementNet/Sections/UniformGeometric1DSection.cs
+++ b/BriefFiniteElementNet/Sections/UniformGeometric1DSection.cs
@@ -52,67 +52,29 @@ namespace BriefFiniteElementNet.Sections
             set { _geometry = value; }
         }
 
+
+        /// <summary>
+        /// If sets to true, all geometric properties are calculated based on centroid, not coordination system origins.
+        /// for more info see pull request #34
+        /// </summary>
+        /// <remarks>
+        /// If set to true, then all properties are calculated based on centroid, not coordination system origins. In this case <see cref="Qy"/> and <see cref="Qz"/> are zeros,
+        /// <see cref="Iy"/> and <see cref="Iz"/> and <see cref="Iyz"/> are calculated based on the section centroid. <see cref="A"/> do not change.
+        /// </remarks>
+        public bool ResetCentroid
+        {
+            get { return _resetCentroid; }
+            set
+            {
+                _resetCentroid = value;
+            }
+        }
+
+        private bool _resetCentroid = true;
+
         public override _1DCrossSectionGeometricProperties GetCrossSectionPropertiesAt(double xi)
         {
-            var buf = new _1DCrossSectionGeometricProperties();
-
-            {
-                var lastPoint = this._geometry[this._geometry.Length - 1];
-
-                if (lastPoint != _geometry[0])
-                    throw new InvalidOperationException("First point and last point ot PolygonYz should put on each other");
-
-                double a = 0, iy = 0, iz = 0, ixy = 0, sy = 0, sz = 0, yc = 0, zc = 0;
-
-                var x = new double[this._geometry.Length];
-                var y = new double[this._geometry.Length];
-
-                for (int i = 0; i < _geometry.Length; i++)
-                {
-                    x[i] = _geometry[i].Y;
-                    y[i] = _geometry[i].Z;
-                }
-
-                var l = _geometry.Length - 1;
-                for (var i = 0; i < l; i++)
-                {
-                    a += (x[i] - x[i + 1]) * (y[i] + y[i + 1]) / 2.0;
-                    iy += (y[i] * y[i] + y[i + 1] * y[i + 1]) * (x[i] - x[i + 1]) * (y[i] + y[i + 1]) / 12.0;
-                    iz += (x[i] * x[i] + x[i + 1] * x[i + 1]) * (y[i + 1] - y[i]) * (x[i] + x[i + 1]) / 12.0;
-                    ixy += (iy + iz);
-                    sy += (x[i] - x[i + 1]) * (y[i] * y[i] + y[i] * y[i + 1] + y[i + 1] * y[i + 1]) / 6;
-                    sz += -(y[i] - y[i + 1]) * (x[i] * x[i] + x[i] * x[i + 1] + x[i + 1] * x[i + 1]) / 6;
-                }
-                yc = sz / a;
-                zc = sy / a;
-                //if the base axis is not the centroid axis, all the point need move
-                if (Math.Abs(yc) > 0.00001 || Math.Abs(zc) > 0.00001)
-                {
-                    for (int i = 0; i < _geometry.Length; i++)
-                    {
-                        x[i] = _geometry[i].Y - yc;
-                        y[i] = _geometry[i].Z - zc;
-                    }
-                    iy = 0;
-                    iz = 0;
-                    ixy = 0;
-                    for (var i = 0; i < l; i++)
-                    {
-                        iy += (y[i] * y[i] + y[i + 1] * y[i + 1]) * (x[i] - x[i + 1]) * (y[i] + y[i + 1]) / 12.0;
-                        iz += (x[i] * x[i] + x[i + 1] * x[i + 1]) * (y[i + 1] - y[i]) * (x[i] + x[i + 1]) / 12.0;
-                        ixy += (iy + iz);
-                    }
-                }
-                
-                buf.A = Math.Abs(a);
-                buf.Iz = Math.Abs(iz);
-                buf.Iy = Math.Abs(iy);
-                buf.J = Math.Abs(ixy);
-                buf.Ay = Math.Abs(a);//TODO: Ay is not equal to A, this is temporary fix
-                buf.Az = Math.Abs(a);//TODO: Az is not equal to A, this is temporary fix
-            }
-
-            return buf;
+            return _1DCrossSectionGeometricProperties.Calculate(this.Geometry,this._resetCentroid);
         }
 
 

--- a/BriefFiniteElementNet/Sections/UniformParametric1DSection.cs
+++ b/BriefFiniteElementNet/Sections/UniformParametric1DSection.cs
@@ -22,7 +22,6 @@ namespace BriefFiniteElementNet.Sections
             info.AddValue("_a", _a);
             info.AddValue("_iy", _iy);
             info.AddValue("_iz", _iz);
-            info.AddValue("_j", _j);
             info.AddValue("_ay", _ay);
             info.AddValue("_az", _az);
 
@@ -35,7 +34,6 @@ namespace BriefFiniteElementNet.Sections
             _a = info.GetDouble("_a");
             _iy = info.GetDouble("_iy");
             _iz = info.GetDouble("_iz");
-            _j = info.GetDouble("_j");
             _ay = info.GetDouble("_ay");
             _az = info.GetDouble("_az");
         }
@@ -50,13 +48,26 @@ namespace BriefFiniteElementNet.Sections
         /// <param name="a">The area of section in m^2</param>
         /// <param name="iy">The Second Moment of Area of section regard to Z axis.</param>
         /// <param name="iz">The Second Moment of Area of section regard to Y axis.</param>
-        /// <param name="j">The polar moment of inertial.</param>
+        /// <param name="j">The polar moment of inertial.</param>\
+        [Obsolete("param J not being used. use UniformParametric1DSection(double a, double iy, double iz) instead")]
         public UniformParametric1DSection(double a, double iy, double iz, double j)
         {
             _a = a;
             _iy = iy;
             _iz = iz;
-            _j = j;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="a">The area of section in m^2</param>
+        /// <param name="iy">The Second Moment of Area of section regard to Z axis.</param>
+        /// <param name="iz">The Second Moment of Area of section regard to Y axis.</param>
+        public UniformParametric1DSection(double a, double iy, double iz)
+        {
+            _a = a;
+            _iy = iy;
+            _iz = iz;
         }
 
         /// <summary>
@@ -73,7 +84,6 @@ namespace BriefFiniteElementNet.Sections
         private double _az;
         private double _iy;
         private double _iz;
-        private double _j;
 
         /// <summary>
         /// Gets or sets a.
@@ -146,21 +156,22 @@ namespace BriefFiniteElementNet.Sections
         }
 
         /// <summary>
-        /// Gets or sets the j.
+        /// Gets the polar moment of inertia (J).
         /// </summary>
         /// <value>
         /// The polar moment of inertial.
         /// </value>
         /// <remarks>
+        /// this is read only property, to change it set either <see cref="Iy"/> or <see cref="Iz"/> as J=Iy+Iz
         ///     /          /
         /// J= | ρ². dA = | (y²+z²).dA = <see cref="Iy"/> + <see cref="Iz"/> 
         ///    /A         /A
         /// </remarks>
         public double J
         {
-            get { return _j; }
-            set { _j = value; }
+            get { return _iy + _iz; }
         }
+
 
         public override _1DCrossSectionGeometricProperties GetCrossSectionPropertiesAt(double xi)
         {
@@ -171,7 +182,6 @@ namespace BriefFiniteElementNet.Sections
             buf.Az = this._az;
             buf.Iy = this._iy;
             buf.Iz = this._iz;
-            buf.J = this._j;
 
             return buf;
         }

--- a/BriefFiniteElementNet/StructureGenerator.cs
+++ b/BriefFiniteElementNet/StructureGenerator.cs
@@ -106,7 +106,6 @@ namespace BriefFiniteElementNet
                     sec.A = b * h;
                     sec.Iy = b * b * b * h / 12;
                     sec.Iz = h * h * h * b / 12;
-                    sec.J = (sec.Iy + sec.Iz) / 2;//!!! 
 
                     br.Section = sec;
                 }
@@ -369,7 +368,7 @@ namespace BriefFiniteElementNet
                 var a = h * w;
                 var iy = h * h * h * w / 12;
                 var iz = w * w * w * h / 12;
-                var j = iy + iz;
+                //var j = iy + iz;
                 var e= RandomHelper.GetRandomNumber(100e9, 200e9);
                 var nu = RandomHelper.GetRandomNumber(0.2, 0.3);
 
@@ -379,7 +378,7 @@ namespace BriefFiniteElementNet
                 sec.A = a;
                 sec.Iy = iy;
                 sec.Iz = iz;
-                sec.J = j;
+                //sec.J = j;
 
             }
 


### PR DESCRIPTION
Improved the GetCrossSectionPropertiesAt method.
If the base axis is not the centroid axis, the location of the centroid axis will be calculated, and all the points will be moved to calculate the inertia moment again.
So, almost all the section types are sustained.