### PR TITLE
Cleanup utility classes

### DIFF
--- a/BriefFiniteElementNet.BenchmarkApplication/BriefFiniteElementNet.BenchmarkApplication.csproj
+++ b/BriefFiniteElementNet.BenchmarkApplication/BriefFiniteElementNet.BenchmarkApplication.csproj
@@ -34,8 +34,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CSparse, Version=3.4.7.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\CSparse.3.4.7\lib\net45\CSparse.dll</HintPath>
+    <Reference Include="CSparse, Version=3.4.9.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\CSparse.3.4.9\lib\net45\CSparse.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/BriefFiniteElementNet.BenchmarkApplication/packages.config
+++ b/BriefFiniteElementNet.BenchmarkApplication/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CSparse" version="3.4.7" targetFramework="net45" />
+  <package id="CSparse" version="3.4.9" targetFramework="net45" />
 </packages>

--- a/BriefFiniteElementNet.CodeProjectExamples/BriefFiniteElementNet.CodeProjectExamples.csproj
+++ b/BriefFiniteElementNet.CodeProjectExamples/BriefFiniteElementNet.CodeProjectExamples.csproj
@@ -36,8 +36,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CSparse, Version=3.4.7.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\CSparse.3.4.7\lib\net45\CSparse.dll</HintPath>
+    <Reference Include="CSparse, Version=3.4.9.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\CSparse.3.4.9\lib\net45\CSparse.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/BriefFiniteElementNet.CodeProjectExamples/packages.config
+++ b/BriefFiniteElementNet.CodeProjectExamples/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CSparse" version="3.4.7" targetFramework="net45" />
+  <package id="CSparse" version="3.4.9" targetFramework="net45" />
 </packages>

--- a/BriefFiniteElementNet.Common/BriefFiniteElementNet.Common.csproj
+++ b/BriefFiniteElementNet.Common/BriefFiniteElementNet.Common.csproj
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CSparse" Version="3.4.7" />
+    <PackageReference Include="CSparse" Version="3.4.9" />
   </ItemGroup>
 
 </Project>

--- a/BriefFiniteElementNet.Common/MathUtil.cs
+++ b/BriefFiniteElementNet.Common/MathUtil.cs
@@ -2,21 +2,14 @@
 ///
 using System;
 
-
 namespace BriefFiniteElementNet.Common
 {
     public static class MathUtil
     {
         /// <summary>
-        /// Determines val1 equals val2 or not.
+        /// The epsilon, threshold using for determining whether two mumbers are equal or not
         /// </summary>
-        /// <param name="val1">The val1.</param>
-        /// <param name="val2">The val2.</param>
-        /// <returns>true if val1 == val2 else false</returns>
-        public static bool Equals(double val1, double val2)
-        {
-            return Equals(val1, val2, Epsilon);
-        }
+        public static double Epsilon = 1e-8;
 
         /// <summary>
         /// Determines val1 equals val2 or not.
@@ -34,19 +27,52 @@ namespace BriefFiniteElementNet.Common
             return diff <= epsilon;
         }
 
-
         /// <summary>
-        /// The epsilon, threshold using for determining whether two mumbers are equal or not
+        /// Fills the array with specified value
         /// </summary>
-        public static double Epsilon = 1e-8;
+        /// <typeparam name="T"></typeparam>
+        /// <param name="arr"></param>
+        /// <param name="val"></param>
+        public static void FillWith<T>(this T[] arr, T val)
+        {
+            if (arr != null)
+                for (var i = 0; i < arr.Length; i++)
+                    arr[i] = val;
+        }
 
+        public static int FirstIndexOf<T>(this T[] arr, T val)
+        {
+            if (arr != null)
+                for (var i = 0; i < arr.Length; i++)
+                    if (SafeEquals(arr[i], val))
+                        return i;
+
+            return -1;
+        }
+
+        private static bool SafeEquals(object o1,object o2)
+        {
+            if (ReferenceEquals(o1, o2))
+                return true;
+
+            if (ReferenceEquals(o1, null) || ReferenceEquals(o2, null))
+                return false;
+
+            return o1.Equals(o2);
+        }
+
+        // TODO: only used in legacy code, move to corresponding assembly?
 
         /// <summary>
         /// Fills the lower triangle from upper triangle.
         /// </summary>
         /// <param name="mtx">The Matrix (square matrix).</param>
-        /// <remarks>In element stiffness matrix the lower triangle of matrix is symmetry of upper triangle of matrix (matrix is symmetric)
-        /// For improving performance, it is suggested that only upper part (and diagonal) of member stiffness matrix be calculated and lower triangular be mirrored from upper part using this method</remarks>
+        /// <remarks>
+        /// In element stiffness matrix the lower triangle of matrix is symmetry of upper triangle
+        /// of matrix (matrix is symmetric). For improving performance, it is suggested that only
+        /// upper part (and diagonal) of member stiffness matrix be calculated and lower triangular
+        /// be mirrored from upper part using this method
+        /// </remarks>
         public static void FillLowerTriangleFromUpperTriangle(Matrix mtx)
         {
             var c = mtx.RowCount;
@@ -57,6 +83,18 @@ namespace BriefFiniteElementNet.Common
 
         }
 
+        /* UNUSED
+         * 
+        /// <summary>
+        /// Determines val1 equals val2 or not.
+        /// </summary>
+        /// <param name="val1">The val1.</param>
+        /// <param name="val2">The val2.</param>
+        /// <returns>true if val1 == val2 else false</returns>
+        public static bool Equals_(double val1, double val2)
+        {
+            return Equals(val1, val2, Epsilon);
+        }
 
         /// <summary>
         /// Calculates the minus of two array (a-b)
@@ -74,47 +112,6 @@ namespace BriefFiniteElementNet.Common
             return buf;
         }
 
-
-
-        /// <summary>
-        /// Fills the array with specified value
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="arr"></param>
-        /// <param name="val"></param>
-        public static void FillWith<T>(this T[] arr, T val)
-        {
-            if (arr != null)
-                for (var i = 0; i < arr.Length; i++)
-                    arr[i] = val;
-        }
-
-        public static int FirstIndexOf<T>(this T[] arr, T val)
-        {
-
-            if (arr != null)
-                for (var i = 0; i < arr.Length; i++)
-                    if (SafeEquals(arr[i], val))
-                        return i;
-
-            return -1;
-        }
-
-
-
-        public static bool SafeEquals(object o1,object o2)
-        {
-            if (ReferenceEquals(o1, o2))
-                return true;
-
-            if (ReferenceEquals(o1, null) || ReferenceEquals(o2, null))
-                return false;
-
-            return o1.Equals(o2);
-        }
-
-
-
-        
+        //*/
     }
 }

--- a/BriefFiniteElementNet.Common/MathUtil.cs
+++ b/BriefFiniteElementNet.Common/MathUtil.cs
@@ -61,7 +61,7 @@ namespace BriefFiniteElementNet.Common
             return o1.Equals(o2);
         }
 
-        // TODO: only used in legacy code, move to corresponding assembly?
+        // TODO: LEGACY CODE - FillLowerTriangleFromUpperTriangle, move out of main assembly?
 
         /// <summary>
         /// Fills the lower triangle from upper triangle.
@@ -84,7 +84,7 @@ namespace BriefFiniteElementNet.Common
         }
 
         /* UNUSED
-         * 
+
         /// <summary>
         /// Determines val1 equals val2 or not.
         /// </summary>

--- a/BriefFiniteElementNet.Controls/BriefFiniteElementNet.Controls.csproj
+++ b/BriefFiniteElementNet.Controls/BriefFiniteElementNet.Controls.csproj
@@ -34,8 +34,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CSparse, Version=3.4.7.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\CSparse.3.4.7\lib\net45\CSparse.dll</HintPath>
+    <Reference Include="CSparse, Version=3.4.9.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\CSparse.3.4.9\lib\net45\CSparse.dll</HintPath>
     </Reference>
     <Reference Include="HelixToolkit, Version=2.12.0.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
       <HintPath>..\packages\HelixToolkit.2.12.0\lib\netstandard1.1\HelixToolkit.dll</HintPath>

--- a/BriefFiniteElementNet.Controls/packages.config
+++ b/BriefFiniteElementNet.Controls/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CSparse" version="3.4.7" targetFramework="net45" />
+  <package id="CSparse" version="3.4.9" targetFramework="net45" />
   <package id="HelixToolkit" version="2.12.0" targetFramework="net45" />
   <package id="HelixToolkit.Wpf" version="2.12.0" targetFramework="net45" />
   <package id="OxyPlot.Core" version="2.0.0" targetFramework="net45" />

--- a/BriefFiniteElementNet.CustomElements/BriefFiniteElementNet.CustomElements.csproj
+++ b/BriefFiniteElementNet.CustomElements/BriefFiniteElementNet.CustomElements.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CSparse" Version="3.4.7" />
+    <PackageReference Include="CSparse" Version="3.4.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BriefFiniteElementNet.CustomElements/ElementHelpers/HexaHedralHelper.cs
+++ b/BriefFiniteElementNet.CustomElements/ElementHelpers/HexaHedralHelper.cs
@@ -523,9 +523,9 @@ namespace BriefFiniteElementNet.Elements.ElementHelpers
 
                         var shp2 = hex.MatrixPool.Allocate(3, shp.ColumnCount);
 
-                        shp2.AssembleInside(shp, 0, 0);
-                        shp2.AssembleInside(shp, 1, 0);
-                        shp2.AssembleInside(shp, 2, 0);
+                        shp2.SetSubMatrix(0, 0, shp);
+                        shp2.SetSubMatrix(1, 0, shp);
+                        shp2.SetSubMatrix(2, 0, shp);
 
 
                         var j = GetJMatrixAt(targetElement, xi, 0, 0);

--- a/BriefFiniteElementNet.DebuggerVisualizers/BriefFiniteElementNet.DebuggerVisualizers.csproj
+++ b/BriefFiniteElementNet.DebuggerVisualizers/BriefFiniteElementNet.DebuggerVisualizers.csproj
@@ -36,8 +36,8 @@
     <RunPostBuildEvent>OnOutputUpdated</RunPostBuildEvent>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CSparse, Version=3.4.7.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\CSparse.3.4.7\lib\net45\CSparse.dll</HintPath>
+    <Reference Include="CSparse, Version=3.4.9.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\CSparse.3.4.9\lib\net45\CSparse.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.DebuggerVisualizers, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="PresentationCore" />

--- a/BriefFiniteElementNet.DebuggerVisualizers/packages.config
+++ b/BriefFiniteElementNet.DebuggerVisualizers/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CSparse" version="3.4.7" targetFramework="net45" />
+  <package id="CSparse" version="3.4.9" targetFramework="net45" />
 </packages>

--- a/BriefFiniteElementNet.Legacy/FrameElement2Node.cs
+++ b/BriefFiniteElementNet.Legacy/FrameElement2Node.cs
@@ -838,14 +838,14 @@ namespace BriefFiniteElementNet
                     //  z  y  I  y
                     //  z  z  z  w
                     y.Scale(2.0/3.0);
-                    buf.AssembleInside(-y, 0, 3);
-                    buf.AssembleInside(w, 3, 3);
-                    buf.AssembleInside(y, 6, 3);
-                    //buf.AssembleInside(z, 9, 3); no need!
-                    buf.AssembleInside(-y, 0, 9);
-                    //buf.AssembleInside(z, 3, 9); no need!
-                    buf.AssembleInside(y, 6, 9);
-                    buf.AssembleInside(w, 9, 9);
+                    buf.SetSubMatrix(0, 3, -y);
+                    buf.SetSubMatrix(3, 3, w);
+                    buf.SetSubMatrix(6, 3, y);
+                    //buf.SetSubMatrix(9, 3, z); no need!
+                    buf.SetSubMatrix(0, 9, -y);
+                    //buf.SetSubMatrix(3, 9, z); no need!
+                    buf.SetSubMatrix(6, 9, y);
+                    buf.SetSubMatrix(9, 9, w);
 
                     break;
                 case 1:
@@ -855,10 +855,10 @@ namespace BriefFiniteElementNet
                     //  z  w  z  z
                     //  z  y  I  z
                     //  z  x  z  I
-                    buf.AssembleInside(-y, 0, 3);
-                    buf.AssembleInside(w, 3, 3);
-                    buf.AssembleInside(y, 6, 3);
-                    buf.AssembleInside(x, 9, 3);
+                    buf.SetSubMatrix(0, 3, -y);
+                    buf.SetSubMatrix(3, 3, w);
+                    buf.SetSubMatrix(6, 3, y);
+                    buf.SetSubMatrix(9, 3, x);
 
                     break;
                 case 2:
@@ -868,10 +868,10 @@ namespace BriefFiniteElementNet
                     //  z  I  z  x
                     //  z  z  I  y
                     //  z  z  z  w
-                    buf.AssembleInside(-y, 0, 9);
-                    buf.AssembleInside(x, 3, 9);
-                    buf.AssembleInside(y, 6, 9);
-                    buf.AssembleInside(w, 9, 9);
+                    buf.SetSubMatrix(0, 9, -y);
+                    buf.SetSubMatrix(3, 9, x);
+                    buf.SetSubMatrix(6, 9, y);
+                    buf.SetSubMatrix(9, 9, w);
 
                     break;
                 case 3:

--- a/BriefFiniteElementNet.Legacy/SolveExtensions.cs
+++ b/BriefFiniteElementNet.Legacy/SolveExtensions.cs
@@ -35,7 +35,7 @@ namespace BriefFiniteElementNet.Legacy
             var fc = thiis.ConcentratedForces[loadCase] = thiis.GetTotalConcentratedForceVector(loadCase);
 
 
-            var ft = fe.Plus(fc);
+            var ft = fe.Add(fc);
 
 
             var fr = pf.Multiply(ft);
@@ -107,7 +107,7 @@ namespace BriefFiniteElementNet.Legacy
             double[] ufr = new double[map.RMap2.Length];
             //string message;
 
-            var input = ffr.Minus(krd.ReleasedFixedPart.Multiply(usr));
+            var input = ffr.Subtract(krd.ReleasedFixedPart.Multiply(usr));
 
 
             solver.Solve(input, ufr);
@@ -115,9 +115,9 @@ namespace BriefFiniteElementNet.Legacy
             //if (res2 != SolverResult.Success)
             //    throw new BriefFiniteElementNetException(message);
 
-            var fpsr = krd.FixedReleasedPart.Multiply(ufr).Plus(krd.FixedFixedPart.Multiply(usr));
+            var fpsr = krd.FixedReleasedPart.Multiply(ufr).Add(krd.FixedFixedPart.Multiply(usr));
 
-            var fsrt = fpsr.Minus(fsr);// no needed
+            var fsrt = fpsr.Subtract(fsr);// no needed
 
             var fx = thiis.SupportReactions[loadCase] = new double[6 * n];
 

--- a/BriefFiniteElementNet.Legacy/SolveExtensions.cs
+++ b/BriefFiniteElementNet.Legacy/SolveExtensions.cs
@@ -71,7 +71,7 @@ namespace BriefFiniteElementNet.Legacy
 
                 var minAbsDiag = double.MaxValue;
 
-                foreach (var tpl in krd.ReleasedReleasedPart.EnumerateIndexed2())
+                foreach (var tpl in krd.ReleasedReleasedPart.EnumerateIndexed())
                 {
                     if (tpl.Item1 == tpl.Item2)
                         minAbsDiag = Math.Min(minAbsDiag, Math.Abs(tpl.Item3));

--- a/BriefFiniteElementNet.Solvers/BriefFiniteElementNet.Solvers.csproj
+++ b/BriefFiniteElementNet.Solvers/BriefFiniteElementNet.Solvers.csproj
@@ -31,8 +31,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CSparse, Version=3.4.7.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\CSparse.3.4.7\lib\net40\CSparse.dll</HintPath>
+    <Reference Include="CSparse, Version=3.4.9.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\CSparse.3.4.9\lib\net40\CSparse.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/BriefFiniteElementNet.Solvers/packages.config
+++ b/BriefFiniteElementNet.Solvers/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CSparse" version="3.4.7" targetFramework="net40" />
+  <package id="CSparse" version="3.4.9" targetFramework="net40" />
 </packages>

--- a/BriefFiniteElementNet.TestConsole/BriefFiniteElementNet.TestConsole.csproj
+++ b/BriefFiniteElementNet.TestConsole/BriefFiniteElementNet.TestConsole.csproj
@@ -35,8 +35,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CSparse, Version=3.4.7.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\CSparse.3.4.7\lib\net45\CSparse.dll</HintPath>
+    <Reference Include="CSparse, Version=3.4.9.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\CSparse.3.4.9\lib\net45\CSparse.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/BriefFiniteElementNet.TestConsole/Program.cs
+++ b/BriefFiniteElementNet.TestConsole/Program.cs
@@ -405,8 +405,8 @@ namespace BriefFiniteElementNet.TestConsole
 
             var a = crd.ToCCs();
 
-            var t = rref.CalculateDisplacementPermutation(a).Item1.ToDenseMatrix();
-      
+            var t = Matrix.OfMatrix(rref.CalculateDisplacementPermutation(a).Item1); // sparse -> dense
+
         }
 
 
@@ -1236,7 +1236,7 @@ namespace BriefFiniteElementNet.TestConsole
             crd.At(4, 4, -5);
 
             var sp = crd.ToCCs().Transpose();
-            var dns = sp.ToDenseMatrix();
+            var dns = Matrix.OfMatrix(sp); // sparse -> dense
 
         }
 

--- a/BriefFiniteElementNet.TestConsole/packages.config
+++ b/BriefFiniteElementNet.TestConsole/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CSparse" version="3.4.7" targetFramework="net45" />
+  <package id="CSparse" version="3.4.9" targetFramework="net45" />
 </packages>

--- a/BriefFiniteElementNet.Validation.Ui/BriefFiniteElementNet.Validation.Ui.csproj
+++ b/BriefFiniteElementNet.Validation.Ui/BriefFiniteElementNet.Validation.Ui.csproj
@@ -35,8 +35,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CSparse, Version=3.4.7.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\CSparse.3.4.7\lib\net45\CSparse.dll</HintPath>
+    <Reference Include="CSparse, Version=3.4.9.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\CSparse.3.4.9\lib\net45\CSparse.dll</HintPath>
     </Reference>
     <Reference Include="HtmlTags, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\HtmlTags.3.0.0.186\lib\4.0\HtmlTags.dll</HintPath>

--- a/BriefFiniteElementNet.Validation.Ui/packages.config
+++ b/BriefFiniteElementNet.Validation.Ui/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CSparse" version="3.4.7" targetFramework="net45" />
+  <package id="CSparse" version="3.4.9" targetFramework="net45" />
   <package id="HtmlTags" version="3.0.0.186" targetFramework="net40" />
 </packages>

--- a/BriefFiniteElementNet.Validation/BriefFiniteElementNet.Validation.csproj
+++ b/BriefFiniteElementNet.Validation/BriefFiniteElementNet.Validation.csproj
@@ -36,8 +36,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CSparse, Version=3.4.7.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\CSparse.3.4.7\lib\net45\CSparse.dll</HintPath>
+    <Reference Include="CSparse, Version=3.4.9.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\CSparse.3.4.9\lib\net45\CSparse.dll</HintPath>
     </Reference>
     <Reference Include="HtmlTags, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\HtmlTags.3.0.0.186\lib\4.0\HtmlTags.dll</HintPath>

--- a/BriefFiniteElementNet.Validation/packages.config
+++ b/BriefFiniteElementNet.Validation/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CSparse" version="3.4.7" targetFramework="net45" />
+  <package id="CSparse" version="3.4.9" targetFramework="net45" />
   <package id="HtmlTags" version="3.0.0.186" targetFramework="net40" />
   <package id="NUnit" version="3.12.0" targetFramework="net45" />
 </packages>

--- a/BriefFiniteElementNet/BriefFiniteElementNet.csproj
+++ b/BriefFiniteElementNet/BriefFiniteElementNet.csproj
@@ -61,7 +61,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CSparse" Version="3.4.7" />
+    <PackageReference Include="CSparse" Version="3.4.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BriefFiniteElementNet/Extensions.cs
+++ b/BriefFiniteElementNet/Extensions.cs
@@ -1,16 +1,11 @@
-﻿using System;
+﻿using BriefFiniteElementNet.Common;
+using BriefFiniteElementNet.Geometry;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
-using System.Text;
 using System.Xml;
-using CSparse.Double;
-using BriefFiniteElementNet.Geometry;
-using CSparse.Storage;
-using BriefFiniteElementNet.ElementHelpers;
-using BriefFiniteElementNet.Elements;
-using BriefFiniteElementNet.Common;
 
 namespace BriefFiniteElementNet
 {
@@ -37,13 +32,13 @@ namespace BriefFiniteElementNet
             return Math.Abs(x - y) < Math.Abs(tol);
         }
 
-        // TODO: only used in legacy code, move to correspoding assembly?
+        // TODO: only used in legacy code, move to corresponding assembly?
         public static Matrix ToMatrix(this Point pt)
         {
             return Matrix.OfVector(new[] { pt.X, pt.Y, pt.Z });
         }
 
-        // TODO: only used in legacy code, move to correspoding assembly?
+        // TODO: only used in legacy code, move to corresponding assembly?
         public static Point ToPoint(this Matrix pt)
         {
             if (pt.RowCount != 3 || pt.ColumnCount != 1)

--- a/BriefFiniteElementNet/Extensions.cs
+++ b/BriefFiniteElementNet/Extensions.cs
@@ -32,13 +32,13 @@ namespace BriefFiniteElementNet
             return Math.Abs(x - y) < Math.Abs(tol);
         }
 
-        // TODO: only used in legacy code, move to corresponding assembly?
+        // TODO: LEGACY CODE - ToMatrix, move out of main assembly?
         public static Matrix ToMatrix(this Point pt)
         {
             return Matrix.OfVector(new[] { pt.X, pt.Y, pt.Z });
         }
 
-        // TODO: only used in legacy code, move to corresponding assembly?
+        // TODO: LEGACY CODE - ToPoint, move out of main assembly?
         public static Point ToPoint(this Matrix pt)
         {
             if (pt.RowCount != 3 || pt.ColumnCount != 1)
@@ -207,8 +207,11 @@ namespace BriefFiniteElementNet
 
         #region Double array extensions
 
-        public static double[] Minus(this double[] x, double[] y)
+        public static double[] Subtract(this double[] x, double[] y)
         {
+            if (x.Length != y.Length)
+                throw new InvalidOperationException();
+
             var buf = (double[])x.Clone();
 
             for (int i = 0; i < buf.Length; i++)
@@ -219,25 +222,16 @@ namespace BriefFiniteElementNet
             return buf;
         }
 
-        public static double[] Plus(this double[] x, double[] y)
+        public static double[] Add(this double[] x, double[] y)
         {
+            if (x.Length != y.Length)
+                throw new InvalidOperationException();
+
             var buf = (double[])x.Clone();
 
             for (int i = 0; i < buf.Length; i++)
             {
                 buf[i] += y[i];
-            }
-
-            return buf;
-        }
-
-        public static double[] Plus(this double[] x, double[] y,double coef)
-        {
-            var buf = (double[])x.Clone();
-
-            for (int i = 0; i < buf.Length; i++)
-            {
-                buf[i] += coef*y[i];
             }
 
             return buf;
@@ -299,6 +293,18 @@ namespace BriefFiniteElementNet
         #endregion
 
         /* UNUSED
+
+        public static double[] Plus(this double[] x, double[] y, double coef)
+        {
+            var buf = (double[])x.Clone();
+
+            for (int i = 0; i < buf.Length; i++)
+            {
+                buf[i] += coef*y[i];
+            }
+
+            return buf;
+        }
 
         public static double[] Negate(this double[] arr)
         {

--- a/BriefFiniteElementNet/Extensions.cs
+++ b/BriefFiniteElementNet/Extensions.cs
@@ -32,16 +32,40 @@ namespace BriefFiniteElementNet
                 return new DisposableDenseMatrix(row, cols, element.MatrixPool.Pool);
         }
 
-        public static CSparse.Double.SparseMatrix CloneMatrix(this CSparse.Double.SparseMatrix matrix)
+        public static bool FEquals(this double x, double y, double tol)
         {
-            var buf = new CSparse.Double.SparseMatrix(matrix.RowCount, matrix.ColumnCount, matrix.NonZerosCount);
-
-            buf.RowIndices = (int[])matrix.RowIndices.Clone();
-            buf.ColumnPointers = (int[])matrix.ColumnPointers.Clone();
-            buf.Values = (double[])matrix.Values.Clone();
-
-            return buf;
+            return Math.Abs(x - y) < Math.Abs(tol);
         }
+
+        // TODO: only used in legacy code, move to correspoding assembly?
+        public static Matrix ToMatrix(this Point pt)
+        {
+            return Matrix.OfVector(new[] { pt.X, pt.Y, pt.Z });
+        }
+
+        // TODO: only used in legacy code, move to correspoding assembly?
+        public static Point ToPoint(this Matrix pt)
+        {
+            if (pt.RowCount != 3 || pt.ColumnCount != 1)
+                throw new Exception();
+
+            return new Point(pt[0, 0], pt[1, 0], pt[2, 0]);
+        }
+
+        public static Matrix ToMatrix(this Vector pt)
+        {
+            return Matrix.OfVector(new[] { pt.X, pt.Y, pt.Z });
+        }
+
+        public static Vector ToVector(this Matrix pt)
+        {
+            if (pt.RowCount != 3 || pt.ColumnCount != 1)
+                throw new Exception();
+
+            return new Vector(pt[0, 0], pt[1, 0], pt[2, 0]);
+        }
+
+        #region Matrix extensions
 
         /// <summary>
         /// High performance 3x3 determinant
@@ -94,10 +118,192 @@ namespace BriefFiniteElementNet
 
             return res;
         }
-        public static  bool FEquals(this double x, double y, double tol)
+
+        #endregion
+
+        #region SerializationInfo extensions
+
+        /// <summary>
+        /// Simplify the accessing to <see cref="SerializationInfo.GetValue"/> and then casting the returned type.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="info">The information.</param>
+        /// <param name="name">The name of field.</param>
+        /// <returns></returns>
+        public static T GetValue<T>(this SerializationInfo info, string name)
         {
-            return Math.Abs(x - y) < Math.Abs(tol);
+            return (T) info.GetValue(name, typeof (T));
         }
+
+        public static Type GetFieldType(this SerializationInfo info, string name)
+        {
+            foreach (SerializationEntry entry in info)
+                if (name == entry.Name)
+                    return entry.ObjectType;
+
+            return null;
+        }
+
+        #endregion
+
+        #region Force extensions
+
+        public static Force Sum(this IEnumerable<Force> forces)
+        {
+            var buf = new Force();
+
+            foreach (var force in forces)
+            {
+                buf += force;
+            }
+
+            return buf;
+        }
+
+        public static Force Move(this Force frc, Point location, Point destination)
+        {
+            var r = destination - location;
+            
+            var addMoment = Vector.Cross(r, frc.Forces);
+
+            frc.Moments -= addMoment;
+
+            return frc;
+        }
+
+        public static Force Move(this Force frc, Vector r)
+        {
+            var addMoment = Vector.Cross(r, frc.Forces);
+
+            frc.Moments -= addMoment;
+
+            return frc;
+        }
+
+        #endregion
+
+        #region XmlWriter extensions
+
+        public static void WriteValue<T>(this XmlWriter rwtr, string attributeName, T value)
+        {
+            if (typeof (T).IsValueType)
+                WriteStructValue(rwtr, attributeName, (ValueType) (object) value);
+            else
+                WriteClassValue(rwtr, attributeName, (object) value);
+        }
+
+        public static void WriteClassValue(this XmlWriter rwtr, string attributeName, object value) 
+        {
+            if (!value.IsNull())
+                rwtr.WriteAttributeString(attributeName, value.ToString());
+        }
+
+        public static void WriteStructValue(this XmlWriter rwtr, string attributeName, ValueType value) 
+        {
+            rwtr.WriteAttributeString(attributeName, value.ToString());
+        }
+
+        public static bool IsNull<T>(this T obj) where T : class
+        {
+            return ReferenceEquals(obj, null);
+        }
+
+        #endregion
+
+        #region Double array extensions
+
+        public static double[] Minus(this double[] x, double[] y)
+        {
+            var buf = (double[])x.Clone();
+
+            for (int i = 0; i < buf.Length; i++)
+            {
+                buf[i] -= y[i];
+            }
+
+            return buf;
+        }
+
+        public static double[] Plus(this double[] x, double[] y)
+        {
+            var buf = (double[])x.Clone();
+
+            for (int i = 0; i < buf.Length; i++)
+            {
+                buf[i] += y[i];
+            }
+
+            return buf;
+        }
+
+        public static double[] Plus(this double[] x, double[] y,double coef)
+        {
+            var buf = (double[])x.Clone();
+
+            for (int i = 0; i < buf.Length; i++)
+            {
+                buf[i] += coef*y[i];
+            }
+
+            return buf;
+        }
+
+        #endregion
+
+        #region IEnumerable extensions
+
+        public static int IndexOfReference<T>(this IEnumerable<T> arr, T obj)
+        {
+            var cnt = arr.Count();
+
+            if (typeof(T).IsValueType)
+                throw new Exception();
+
+            var i = 0;
+
+            foreach (var arrMem in arr)
+            {
+                if (ReferenceEquals(arrMem, obj))
+                    return i;
+                i++;
+            }
+
+            return -1;
+        }
+
+        public static TSource MinBy<TSource, TKey>(this IEnumerable<TSource> source,
+            Func<TSource, TKey> selector, IComparer<TKey> comparer)
+        {
+            if (source == null) throw new ArgumentNullException("source");
+            if (selector == null) throw new ArgumentNullException("selector");
+            comparer = comparer ?? Comparer<TKey>.Default;
+
+            using (var sourceIterator = source.GetEnumerator())
+            {
+                if (!sourceIterator.MoveNext())
+                {
+                    throw new InvalidOperationException("Sequence contains no elements");
+                }
+                var min = sourceIterator.Current;
+                var minKey = selector(min);
+                while (sourceIterator.MoveNext())
+                {
+                    var candidate = sourceIterator.Current;
+                    var candidateProjected = selector(candidate);
+                    if (comparer.Compare(candidateProjected, minKey) < 0)
+                    {
+                        min = candidate;
+                        minKey = candidateProjected;
+                    }
+                }
+                return min;
+            }
+        }
+
+
+        #endregion
+
+        /* UNUSED
 
         public static double[] Negate(this double[] arr)
         {
@@ -109,32 +315,6 @@ namespace BriefFiniteElementNet
             }
 
             return arr;
-        }
-
-        public static Matrix ToMatrix(this Point pt)
-        {
-            return Matrix.OfVector(new[] {pt.X, pt.Y, pt.Z});
-        }
-
-        public static Matrix ToMatrix(this Vector pt)
-        {
-            return Matrix.OfVector(new[] { pt.X, pt.Y, pt.Z });
-        }
-
-        public static Point ToPoint(this Matrix pt)
-        {
-            if (pt.RowCount != 3 || pt.ColumnCount != 1)
-                throw new Exception();
-
-            return new Point(pt[0, 0], pt[1, 0], pt[2, 0]);
-        }
-
-        public static Vector ToVector(this Matrix pt)
-        {
-            if (pt.RowCount != 3 || pt.ColumnCount != 1)
-                throw new Exception();
-
-            return new Vector(pt[0, 0], pt[1, 0], pt[2, 0]);
         }
 
         public delegate double FunctionDelegate(double d);
@@ -278,138 +458,6 @@ namespace BriefFiniteElementNet
             return max;
         }
 
-        /// <summary>
-        /// Simplify the accessing to <see cref="SerializationInfo.GetValue"/> and then casting the returned type.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="info">The information.</param>
-        /// <param name="name">The name of field.</param>
-        /// <returns></returns>
-        public static T GetValue<T>(this SerializationInfo info, string name)
-        {
-            return (T) info.GetValue(name, typeof (T));
-        }
-
-        public static Type GetFieldType(this SerializationInfo info, string name)
-        {
-            foreach (SerializationEntry entry in info)
-                if (name == entry.Name)
-                    return entry.ObjectType;
-
-            return null;
-        }
-
-        public static Force Sum(this IEnumerable<Force> forces)
-        {
-            var buf = new Force();
-
-            foreach (var force in forces)
-            {
-                buf += force;
-            }
-
-            return buf;
-        }
-
-        public static Force Move(this Force frc, Point location, Point destination)
-        {
-            var r = destination - location;
-            
-            var addMoment = Vector.Cross(r, frc.Forces);
-
-            frc.Moments -= addMoment;
-
-            return frc;
-        }
-
-        public static Force Move(this Force frc, Vector r)
-        {
-            var addMoment = Vector.Cross(r, frc.Forces);
-
-            frc.Moments -= addMoment;
-
-            return frc;
-        }
-        
-        public static int IndexOfReference<T>(this IEnumerable<T> arr, T obj)
-        {
-            var cnt = arr.Count();
-
-            if (typeof (T).IsValueType)
-                throw new Exception();
-
-            var i = 0;
-
-            foreach (var arrMem in arr)
-            {
-                if (ReferenceEquals(arrMem, obj))
-                    return i;
-                i++;
-            }
-
-            return -1;
-        }
-
-        public static void Restart(this System.Diagnostics.Stopwatch sp)
-        {
-            sp.Stop();
-            sp.Reset();
-            sp.Start();
-        }
-
-        public static Matrix ToDenseMatrix(this SparseMatrix csr)
-        {
-            var buf = new Matrix(csr.RowCount, csr.ColumnCount);
-
-            for (int i = 0; i < csr.ColumnPointers.Length - 1; i++)
-            {
-                var col = i;
-
-                var st = csr.ColumnPointers[i];
-                var en = csr.ColumnPointers[i + 1];
-
-                for (int j = st; j < en; j++)
-                {
-                    var row = csr.RowIndices[j];
-                    buf[row, col] = csr.Values[j];
-                }
-            }
-
-            return buf;
-        }
-
-        public static SparseMatrix ToSparseMatrix(this Matrix csr)
-        {
-            var buf = new CSparse.Storage.CoordinateStorage<double>(csr.RowCount, csr.ColumnCount, 1);
-
-            for (var i = 0; i < csr.RowCount; i++)
-                for (var j = 0; j < csr.ColumnCount; j++)
-                    buf.At(i, j, csr[i, j]);
-
-            return buf.ToCCs();
-        }
-
-        public static Matrix ToDenseMatrix(this CompressedColumnStorage<double> csr)
-        {
-            var buf = new Matrix(csr.RowCount, csr.ColumnCount);
-
-            for (int i = 0; i < csr.ColumnPointers.Length - 1; i++)
-            {
-                var col = i;
-
-                var st = csr.ColumnPointers[i];
-                var en = csr.ColumnPointers[i + 1];
-
-                for (int j = st; j < en; j++)
-                {
-                    var row = csr.RowIndices[j];
-                    buf[row, col] = csr.Values[j];
-                }
-            }
-
-            return buf;
-        }
-
         public static double GetLargestAbsoluteValue(this double[] vals)
         {
             var buf = 0.0;
@@ -465,29 +513,6 @@ namespace BriefFiniteElementNet
         }
 
         /// <summary>
-        /// Assembles the <see cref="submatrix"/> inside the <see cref="main"/> matrix.
-        /// </summary>
-        /// <param name="main">The main matrix.</param>
-        /// <param name="submatrix">The sub matrix.</param>
-        /// <param name="i">The i</param>
-        /// <param name="j">The j</param>
-        public static void AssembleInside(this Matrix main, Matrix submatrix, int i, int j)
-        {
-            if (main.RowCount < i + submatrix.RowCount || main.ColumnCount < j + submatrix.ColumnCount)
-                throw new InvalidOperationException("dimension mismatch");
-
-            for (var _i = 0; _i < submatrix.RowCount; _i++)
-            {
-                for (var _j = 0; _j < submatrix.ColumnCount; _j++)
-                {
-                    main[i + _i, j + _j] = submatrix[_i, _j];
-                }
-            }
-
-        }
-
-
-        /// <summary>
         /// Gets the sum of external loads (both from external sources and supports) which are applying to the node.
         /// </summary>
         /// <param name="node">The node.</param>
@@ -500,66 +525,6 @@ namespace BriefFiniteElementNet
             var force = Force.FromVector(forces, 6*node.Index);
 
             return force;
-        }
-
-        public static void WriteValue<T>(this XmlWriter rwtr, string attributeName, T value)
-        {
-            if (typeof (T).IsValueType)
-                WriteStructValue(rwtr, attributeName, (ValueType) (object) value);
-            else
-                WriteClassValue(rwtr, attributeName, (object) value);
-        }
-
-        public static void WriteClassValue(this XmlWriter rwtr, string attributeName, object value) 
-        {
-            if (!value.IsNull())
-                rwtr.WriteAttributeString(attributeName, value.ToString());
-        }
-
-        public static void WriteStructValue(this XmlWriter rwtr, string attributeName, ValueType value) 
-        {
-            rwtr.WriteAttributeString(attributeName, value.ToString());
-        }
-
-        public static bool IsNull<T>(this T obj) where T : class
-        {
-            return ReferenceEquals(obj, null);
-        }
-
-        public static double[] Minus(this double[] x, double[] y)
-        {
-            var buf = (double[])x.Clone();
-
-            for (int i = 0; i < buf.Length; i++)
-            {
-                buf[i] -= y[i];
-            }
-
-            return buf;
-        }
-
-        public static double[] Plus(this double[] x, double[] y)
-        {
-            var buf = (double[])x.Clone();
-
-            for (int i = 0; i < buf.Length; i++)
-            {
-                buf[i] += y[i];
-            }
-
-            return buf;
-        }
-
-        public static double[] Plus(this double[] x, double[] y,double coef)
-        {
-            var buf = (double[])x.Clone();
-
-            for (int i = 0; i < buf.Length; i++)
-            {
-                buf[i] += coef*y[i];
-            }
-
-            return buf;
         }
 
         public static bool AreAllSame<T>(this IEnumerable<T> objs)
@@ -616,54 +581,6 @@ namespace BriefFiniteElementNet
             return true;
         }
 
-        public static TSource MinBy<TSource, TKey>(this IEnumerable<TSource> source,
-            Func<TSource, TKey> selector, IComparer<TKey> comparer)
-        {
-            if (source == null) throw new ArgumentNullException("source");
-            if (selector == null) throw new ArgumentNullException("selector");
-            comparer = comparer ?? Comparer<TKey>.Default;
-
-            using (var sourceIterator = source.GetEnumerator())
-            {
-                if (!sourceIterator.MoveNext())
-                {
-                    throw new InvalidOperationException("Sequence contains no elements");
-                }
-                var min = sourceIterator.Current;
-                var minKey = selector(min);
-                while (sourceIterator.MoveNext())
-                {
-                    var candidate = sourceIterator.Current;
-                    var candidateProjected = selector(candidate);
-                    if (comparer.Compare(candidateProjected, minKey) < 0)
-                    {
-                        min = candidate;
-                        minKey = candidateProjected;
-                    }
-                }
-                return min;
-            }
-        }
-
-        public static IEnumerable<Tuple<int, int, double>> EnumerateIndexed2(this SparseMatrix mtx)
-        {
-
-            int n = mtx.ColumnCount;
-
-            var ax = mtx.Values;
-            var ap = mtx.ColumnPointers;
-            var ai = mtx.RowIndices;
-
-            for (int i = 0; i < n; i++)
-            {
-                var end = ap[i + 1];
-                for (var j = ap[i]; j < end; j++)
-                {
-                    yield return new Tuple<int, int, double>(ai[j], i, ax[j]);
-                }
-            }
-        }
-
         public static T MinBy<T>(this IEnumerable<T> source, IComparer<T> comparer)
         {
             if (source == null) throw new ArgumentNullException("source");
@@ -694,5 +611,7 @@ namespace BriefFiniteElementNet
                 return min;
             }
         }
+
+        //*/
     }
 }

--- a/BriefFiniteElementNet/FemUtilities/StiffnessCenterFinder.cs
+++ b/BriefFiniteElementNet/FemUtilities/StiffnessCenterFinder.cs
@@ -224,7 +224,7 @@ namespace BriefFiniteElementNet.FemUtilies
 
         public CSR GetAdjacencyGraph(CSR P_delta)
         {
-            var p = P_delta.CloneMatrix();
+            var p = P_delta.Clone();
             
             for (var i = 0; i < p.NonZerosCount; i++)
                 p.Values[i] = 1;

--- a/BriefFiniteElementNet/Mathh/BuiltinGaussDisplacementPermutationFinder.cs
+++ b/BriefFiniteElementNet/Mathh/BuiltinGaussDisplacementPermutationFinder.cs
@@ -173,7 +173,7 @@ namespace BriefFiniteElementNet.Mathh
 
             var p3Crd = new CoordinateStorage<double>(totDofCount, totDofCount - colsToRemove.Count(i => i), 1);
 
-            foreach (var tpl in p2.EnumerateIndexed2())
+            foreach (var tpl in p2.EnumerateIndexed())
             {
                 if (!colsToRemove[tpl.Item2])
                 {

--- a/BriefFiniteElementNet/Mathh/CsparsenetQrDisplacementPermutationCalculator.cs
+++ b/BriefFiniteElementNet/Mathh/CsparsenetQrDisplacementPermutationCalculator.cs
@@ -1,14 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Text;
+﻿using BriefFiniteElementNet.Common;
 using CSparse;
 using CSparse.Double;
 using CSparse.Double.Factorization;
 using CSparse.Factorization;
 using CSparse.Storage;
-using BriefFiniteElementNet.Common;
+using System;
+using System.Linq;
+using System.Reflection;
 
 namespace BriefFiniteElementNet.Mathh
 {
@@ -16,27 +14,18 @@ namespace BriefFiniteElementNet.Mathh
     {
         public Tuple<SparseMatrix, double[]> CalculateDisplacementPermutation(SparseMatrix a)
         {
-
-            // See https://github.com/wo80/CSparse.NET/issues/7#issuecomment-317268696
-
             if (a.RowCount < a.ColumnCount)
             {
+                // See https://github.com/wo80/CSparse.NET/issues/7#issuecomment-317268696
+                //
                 // For a matrix A with rows < columns, SparseQR does a factorization of the
                 // transpose A' so we add zero rows to A and make it square!
-
+                //
                 // Since the matrix entries are in column order, reshaping is just a matter of
                 // setting the correct row count and then reusing the existing storage arrays.
 
-                var b = new SparseMatrix(a.ColumnCount, a.ColumnCount);
-
-                b.ColumnPointers = a.ColumnPointers;
-                b.RowIndices = a.RowIndices;
-                b.Values = a.Values;
-
-                a = b;
+                a = new SparseMatrix(a.ColumnCount, a.ColumnCount, a.Values, a.RowIndices, a.ColumnPointers);
             }
-
-            //var adense = a.ToDenseMatrix();
 
             SparseMatrix buf;
 

--- a/BriefFiniteElementNet/Mathh/CsparsenetQrDisplacementPermutationCalculator.cs
+++ b/BriefFiniteElementNet/Mathh/CsparsenetQrDisplacementPermutationCalculator.cs
@@ -8,34 +8,32 @@ using CSparse.Double;
 using CSparse.Double.Factorization;
 using CSparse.Factorization;
 using CSparse.Storage;
-using CCS = CSparse.Double.SparseMatrix;
 using BriefFiniteElementNet.Common;
 
 namespace BriefFiniteElementNet.Mathh
 {
     public class CsparsenetQrDisplacementPermutationCalculator : IDisplacementPermutationCalculator
     {
-        public Tuple<CCS, double[]> CalculateDisplacementPermutation(CCS a)
+        public Tuple<SparseMatrix, double[]> CalculateDisplacementPermutation(SparseMatrix a)
         {
 
-
-
-
-            
-
-            //based on this solution : https://github.com/wo80/CSparse.NET/issues/7#issuecomment-317268696
+            // See https://github.com/wo80/CSparse.NET/issues/7#issuecomment-317268696
 
             if (a.RowCount < a.ColumnCount)
             {
-                //For a matrix A with rows < columns, SparseQR does a factorization of the transpose A'
-                //so we add zero rows to A and make it rectangular!
+                // For a matrix A with rows < columns, SparseQR does a factorization of the
+                // transpose A' so we add zero rows to A and make it square!
 
-                var a2 = new CoordinateStorage<double>(a.ColumnCount , a.ColumnCount, a.NonZerosCount);
+                // Since the matrix entries are in column order, reshaping is just a matter of
+                // setting the correct row count and then reusing the existing storage arrays.
 
-                foreach (var t in a.EnumerateIndexed())
-                    a2.At(t.Item1, t.Item2, t.Item3);
+                var b = new SparseMatrix(a.ColumnCount, a.ColumnCount);
 
-                a = a2.ToCCs();
+                b.ColumnPointers = a.ColumnPointers;
+                b.RowIndices = a.RowIndices;
+                b.Values = a.Values;
+
+                a = b;
             }
 
             //var adense = a.ToDenseMatrix();
@@ -257,7 +255,7 @@ namespace BriefFiniteElementNet.Mathh
             //var d2 = rightSide.Plus(rightSideDense, -1);
 
 
-            var pdd = (CCS)p_d.ToCCs();
+            var pdd = p_d.ToCCs();
 
             return Tuple.Create(pdd, rightSide);
 

--- a/BriefFiniteElementNet/Mathh/DenseIrrefFinder.cs
+++ b/BriefFiniteElementNet/Mathh/DenseIrrefFinder.cs
@@ -100,7 +100,8 @@ namespace BriefFiniteElementNet.Mathh
 
                 var denseSubSytem = new Matrix(eqnPart.Count, connectedVariables.Count+1);////i'th independent system as dense
 
-                var dns = aTran.ToDenseMatrix();
+                // Convert sparse to dense.
+                //var dns = Matrix.OfMatrix(aTran);
 
                 for (var i = 0; i < eqnPart.Count; i++)
                 {

--- a/BriefFiniteElementNet/Mathh/DenseIrrefFinder.cs
+++ b/BriefFiniteElementNet/Mathh/DenseIrrefFinder.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using BriefFiniteElementNet.Common;
 using CSparse.Double;
 using CSparse.Ordering;
 using CSparse.Storage;
@@ -23,19 +24,19 @@ namespace BriefFiniteElementNet.Mathh
                     singleMemberColumns++;
 
             if (singleMemberColumns == a.RowCount)
-                return a.Clonee();
+                return (CCS)a.Clone();
 
             var pat = new CoordinateStorage<double>(a.RowCount, a.ColumnCount - 1, 1);
             var bCrd = new CoordinateStorage<double>(a.RowCount, a.ColumnCount - 1, 1);//a matrix without last column
 
-            a.EnumerateMembers((row, col, val) =>
-            {
-                if (col != a.ColumnCount - 1)
-                {
-                    pat.At(row, col, 1);
-                    bCrd.At(row, col, val);
-                }
-            });
+            a.EnumerateIndexed((row, col, val) =>
+             {
+                 if (col != a.ColumnCount - 1)
+                 {
+                     pat.At(row, col, 1);
+                     bCrd.At(row, col, val);
+                 }
+             });
             //nonzero pattern of a, except last column
 
             var b = bCrd.ToCCs();
@@ -46,10 +47,10 @@ namespace BriefFiniteElementNet.Mathh
 
 
             var varGraph = pattTr.Multiply(patt);
-            varGraph.Values.SetAllMembers(1);
+            varGraph.Values.FillWith(1);
 
             var eqnGraph = patt.Multiply(pattTr);
-            eqnGraph.Values.SetAllMembers(1);
+            eqnGraph.Values.FillWith(1);
 
 
 

--- a/BriefFiniteElementNet/Mathh/SparseEqSystem.cs
+++ b/BriefFiniteElementNet/Mathh/SparseEqSystem.cs
@@ -72,7 +72,7 @@ namespace BriefFiniteElementNet.Mathh
             }
 
 
-            foreach(var tuple in eqSystem.EnumerateIndexed2())
+            foreach(var tuple in eqSystem.EnumerateIndexed())
             {
                 var rw = tuple.Item1;//tuple.Item1;
                 var col = tuple.Item2;//tuple.Item2;

--- a/BriefFiniteElementNet/StaticLinearAnalysisResult.cs
+++ b/BriefFiniteElementNet/StaticLinearAnalysisResult.cs
@@ -685,7 +685,7 @@ namespace BriefFiniteElementNet
 
                 var minAbsDiag = double.MaxValue;
 
-                foreach(var tpl in krd.ReleasedReleasedPart.EnumerateIndexed2())
+                foreach(var tpl in krd.ReleasedReleasedPart.EnumerateIndexed())
                 {
                     if (tpl.Item1 == tpl.Item2)
                         minAbsDiag = Math.Min(minAbsDiag, Math.Abs(tpl.Item3));

--- a/BriefFiniteElementNet/StaticLinearAnalysisResult.cs
+++ b/BriefFiniteElementNet/StaticLinearAnalysisResult.cs
@@ -649,7 +649,7 @@ namespace BriefFiniteElementNet
             var fc = concentratedForces[loadCase] = GetTotalConcentratedForceVector(loadCase);
             
 
-            var ft = fe.Plus(fc);
+            var ft = fe.Add(fc);
 
 
             var fr = pf.Multiply(ft);
@@ -721,7 +721,7 @@ namespace BriefFiniteElementNet
             double[] ufr = new double[map.RMap2.Length];
             //string message;
 
-            var input = ffr.Minus(krd.ReleasedFixedPart.Multiply(usr));
+            var input = ffr.Subtract(krd.ReleasedFixedPart.Multiply(usr));
 
 
             solver.Solve(input, ufr);
@@ -729,9 +729,9 @@ namespace BriefFiniteElementNet
             //if (res2 != SolverResult.Success)
             //    throw new BriefFiniteElementNetException(message);
 
-            var fpsr = krd.FixedReleasedPart.Multiply(ufr).Plus(krd.FixedFixedPart.Multiply(usr));
+            var fpsr = krd.FixedReleasedPart.Multiply(ufr).Add(krd.FixedFixedPart.Multiply(usr));
 
-            var fsrt = fpsr.Minus(fsr);// no needed
+            var fsrt = fpsr.Subtract(fsr);// no needed
 
             var fx = supportReactions[loadCase] = new double[6*n];
 

--- a/BriefFiniteElementNet/Utils/CalcUtil.cs
+++ b/BriefFiniteElementNet/Utils/CalcUtil.cs
@@ -1351,7 +1351,7 @@ namespace BriefFiniteElementNet
             if (crd.RowCount == 0 || crd.ColumnCount == 0)
                 return new SparseMatrix(0, 0) { ColumnPointers = new int[0], RowIndices = new int[0], Values = new double[0] };
 
-            return (SparseMatrix)SparseMatrix.OfIndexed(crd);
+            return (SparseMatrix)SparseMatrix.OfIndexed(crd, true);
         }
 
         // TODO: EXTENSION - move to Extensions class?

--- a/BriefFiniteElementNet/Utils/CalcUtil.cs
+++ b/BriefFiniteElementNet/Utils/CalcUtil.cs
@@ -1606,7 +1606,7 @@ namespace BriefFiniteElementNet
                         if (extras.ColumnCount != totDofCount + 1)
                             throw new Exception();
 
-                        foreach (var tuple in extras.EnumerateIndexed2())
+                        foreach (var tuple in extras.EnumerateIndexed())
                         {
                             var row = tuple.Item1;
                             var col = tuple.Item2;
@@ -1625,7 +1625,7 @@ namespace BriefFiniteElementNet
                     throw new Exception();
 
 
-                foreach (var tuple in boundaryConditions.EnumerateIndexed2())
+                foreach (var tuple in boundaryConditions.EnumerateIndexed())
                 {
                     var row = tuple.Item1;
                     var col = tuple.Item2;
@@ -1803,7 +1803,7 @@ namespace BriefFiniteElementNet
 
             var p3Crd = new CoordinateStorage<double>(totDofCount, totDofCount - colsToRemove.Count(i => i), 1);
 
-            foreach(var tpl in p2.EnumerateIndexed2())
+            foreach(var tpl in p2.EnumerateIndexed())
             {
                 if (!colsToRemove[tpl.Item2])
                 {
@@ -1850,7 +1850,7 @@ namespace BriefFiniteElementNet
                         if (extras.ColumnCount != totDofCount + 1)
                             throw new Exception();
 
-                        foreach (var tuple in extras.EnumerateIndexed2())
+                        foreach (var tuple in extras.EnumerateIndexed())
                         {
                             var row = tuple.Item1;
                             var col = tuple.Item2;
@@ -1868,7 +1868,7 @@ namespace BriefFiniteElementNet
                 if (boundaryConditions.ColumnCount != totDofCount + 1)
                     throw new Exception();
 
-                foreach (var tuple in boundaryConditions.EnumerateIndexed2())
+                foreach (var tuple in boundaryConditions.EnumerateIndexed())
                 {
                     var row = tuple.Item1;
                     var col = tuple.Item2;
@@ -1890,7 +1890,7 @@ namespace BriefFiniteElementNet
             {
                 var rowNnzs = new int[allEqs.RowCount];//nnz count of each row disregard last column which is right side
 
-                foreach (var tpl in allEqs.EnumerateIndexed2())
+                foreach (var tpl in allEqs.EnumerateIndexed())
                 {
                     if (tpl.Item3 != 0)
                         if (tpl.Item2 != allEqs.ColumnCount - 1)
@@ -2050,7 +2050,7 @@ namespace BriefFiniteElementNet
 
             var lst = new List<int>();
 
-            foreach(var tuple in matrix.EnumerateIndexed2())
+            foreach(var tuple in matrix.EnumerateIndexed())
             {
                 var rw = tuple.Item1;
                 var col = tuple.Item2;


### PR DESCRIPTION
Some legacy extensions methods were replaced with the according CSparse methods.

The files `Extensions.cs`, `CalcUtil.cs` and `MathUtil.cs` now contain a commented section
```
/* UNUSED
...
//*/
```
with code that isn't used (at the moment). Review the functions in this section and delete the code, if you think it won't be used anymore (or move it to the legacy project).

A couple of `TODO` comments have been added. Those can be easily spotted in the task list, look for `TODO: EXTENSION` or `TODO: LEGACY CODE`.

CSparse has been updated to the latest version. `CalcUtil.ToCCs(...)` now uses a new overload which re-uses the coordinate storage arrays.