### PR TITLE
Fix swapped tuple element access in SparseEqSystem.Generate

### DIFF
--- a/Sources/BriefFiniteElementNet/Mathh/StiffnessPermutationMatrix/SparseEqSystem.cs
+++ b/Sources/BriefFiniteElementNet/Mathh/StiffnessPermutationMatrix/SparseEqSystem.cs
@@ -115,8 +115,8 @@ namespace BriefFiniteElementNet.Mathh
                 foreach (var tuple in eq.EnumerateIndexed())
                 {
                     var rw = i;//tuple.Item1;
-                    var col = tuple.Item1;//tuple.Item2;
-                    var val = tuple.Item2;
+                    var col = tuple.Item2;
+                    var val = tuple.Item3;
 
                     if (col != lastCol)
                         colNnzs[col]++;


### PR DESCRIPTION
## Bug Description

In the second overload of `SparseEqSystem.Generate`, the code incorrectly accessed tuple elements when iterating through indexed sparse row data:

```csharp
var rw = i;//tuple.Item1;
var col = tuple.Item1;//tuple.Item2;  // BUG: should be Item2
var val = tuple.Item2;                // BUG: should be Item3
```

This caused the column index to be read from the wrong tuple element, and the value to be read from the column index position instead of the value position.

## Fix

Changed the tuple access to correctly map:
- `Item1` → row index (already correctly using loop variable `i`)
- `Item2` → column index
- `Item3` → value

## Impact

This bug caused incorrect matrix data to be processed when using the second overload of `SparseEqSystem.Generate`, potentially leading to wrong results in finite element calculations.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.